### PR TITLE
Fix logging on retry.

### DIFF
--- a/redo/__init__.py
+++ b/redo/__init__.py
@@ -160,8 +160,8 @@ def retry(action, attempts=5, sleeptime=60, max_sleeptime=5 * 60,
                      jitter=jitter):
         try:
             logfn = log.info if n != 1 else log.debug
-            log_attempt_args += (n, )
-            logfn(*log_attempt_args)
+            logfn_args = log_attempt_args + (n, )
+            logfn(*logfn_args)
             return action(*args, **kwargs)
         except retry_exceptions:
             log.debug("retry: Caught exception: ", exc_info=True)


### PR DESCRIPTION
#51 introduced a bug where the old `attempt` count was never removed from the `log_attempt_args` tuple, and was appended after every retry, resulting in cryptic tracebacks like the following:

```
--- Logging error ---
Traceback (most recent call last):
[snip]
  File "/usr/lib/python3.6/logging/__init__.py", line 338, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
[snip]
  File "/usr/local/lib/service_venv_python3.6/lib/python3.6/site-packages/redo/__init__.py", line 210, in _retriable_wrapper
    **retry_kwargs)
  File "/usr/local/lib/service_venv_python3.6/lib/python3.6/site-packages/redo/__init__.py", line 165, in retry
    return action(*args, **kwargs)
[snip]
  File "/usr/local/lib/service_venv_python3.6/lib/python3.6/site-packages/redo/__init__.py", line 210, in _retriable_wrapper
    **retry_kwargs)
  File "/usr/local/lib/service_venv_python3.6/lib/python3.6/site-packages/redo/__init__.py", line 164, in retry
    logfn(*log_attempt_args)
Message: 'retry: calling %s with args: %s, kwargs: %s, attempt #%d'
Arguments: ('function_name', (), {}, 1, 2, 3)
```

This is resolved by assigning the actual args to `logfn` to a new name, instead of modifying log_attempt_args.